### PR TITLE
Allow run.sh to be invoked from any dir

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -17,4 +17,6 @@
 # Run the application
 # ----------------------------------------------------------------------------
 
-java -jar target/org.wso2.jmc.flamegraph-*.jar $*
+JFG_DIR=$(dirname "$0")
+
+java -jar ${JFG_DIR}/target/org.wso2.jmc.flamegraph-*.jar $*


### PR DESCRIPTION
Having be in the jfr-flame-graph directory to use run.sh is cumbersome. Lets use
$0 to avoid that.