### PR TITLE
Generate flamegraphs for other event types available in a JFR recording

### DIFF
--- a/create_flamegraph.sh
+++ b/create_flamegraph.sh
@@ -36,7 +36,7 @@ function help {
 
 jfr_file=""
 
-while getopts "df:airsx:y:" opts
+while getopts "df:airsx:y:e:" opts
 do
   case $opts in
     f)

--- a/create_flamegraphs.sh
+++ b/create_flamegraphs.sh
@@ -90,7 +90,7 @@ fi
 
 jfr_filename=$(basename $jfr_file)
 
-details=$(${JFG_DIR}/flamegraph-output.sh -ot folded -f $jfr_file -j -t)
+details=$(${JFG_DIR}/flamegraph-output.sh -ot folded $decompress -f $jfr_file -j -t)
 
 echo "$details"
 

--- a/src/main/java/com/github/chrishantha/jfr/flamegraph/output/EventType.java
+++ b/src/main/java/com/github/chrishantha/jfr/flamegraph/output/EventType.java
@@ -7,30 +7,38 @@ import com.beust.jcommander.IStringConverter;
  */
 public enum EventType {
 
-    EVENT_METHOD_PROFILING_SAMPLE("Method Profiling Sample"), 
-    EVENT_ALLOCATION_IN_NEW_TLAB("Allocation in new TLAB", true), 
-    EVENT_ALLOCATION_OUTSIDE_TLAB("Allocation outside TLAB", true), 
-    EVENT_JAVA_EXCEPTION("Java Exception"), 
-    EVENT_JAVA_MONITOR_BLOCKED("Java Monitor Blocked");
+    EVENT_METHOD_PROFILING_SAMPLE("Method Profiling Sample", "cpu"),
+    EVENT_ALLOCATION_IN_NEW_TLAB("Allocation in new TLAB", "allocation-tlab", true), 
+    EVENT_ALLOCATION_OUTSIDE_TLAB("Allocation outside TLAB", "allocation-outside-tlab", true), 
+    EVENT_JAVA_EXCEPTION("Java Exception", "exceptions"),
+    EVENT_JAVA_MONITOR_BLOCKED("Java Monitor Blocked", "monitor-blocked");
 
     /** Name as declared in the JFR recording */
     private final String name;
 
+    /** Id used as a command line option */
+    private final String id;
+
     /** True if the event is allocation-related */
     private final boolean isAllocation;
 
-    EventType(String name, boolean isAllocation) {
+    EventType(String name, String id, boolean isAllocation) {
         this.name = name;
+        this.id = id;
         this.isAllocation = isAllocation;
     }
 
-    EventType(String name) {
-        this(name, false);
+    EventType(String name, String id) {
+        this(name, id, false);
+    }
+
+    public String getName() {
+        return name;
     }
 
     @Override
     public String toString() {
-        return name;
+        return id;
     }
 
     /**
@@ -48,10 +56,12 @@ public enum EventType {
             return EVENT_ALLOCATION_OUTSIDE_TLAB;
         case "exceptions":
             return EVENT_JAVA_EXCEPTION;
-        case "locks":
+        case "monitor-blocked":
             return EVENT_JAVA_MONITOR_BLOCKED;
-        default:
+        case "cpu":
             return EVENT_METHOD_PROFILING_SAMPLE;
+        default:
+            throw new IllegalArgumentException("Event type [" + name + "] does not exist.");
         }
     }
 

--- a/src/main/java/com/github/chrishantha/jfr/flamegraph/output/EventType.java
+++ b/src/main/java/com/github/chrishantha/jfr/flamegraph/output/EventType.java
@@ -1,0 +1,64 @@
+package com.github.chrishantha.jfr.flamegraph.output;
+
+import com.beust.jcommander.IStringConverter;
+
+/**
+ * Different types of events possibly available in a JFR recording.
+ */
+public enum EventType {
+
+    EVENT_METHOD_PROFILING_SAMPLE("Method Profiling Sample"), 
+    EVENT_ALLOCATION_IN_NEW_TLAB("Allocation in new TLAB", true), 
+    EVENT_ALLOCATION_OUTSIDE_TLAB("Allocation outside TLAB", true), 
+    EVENT_JAVA_EXCEPTION("Java Exception"), 
+    EVENT_JAVA_MONITOR_BLOCKED("Java Monitor Blocked");
+
+    /** Name as declared in the JFR recording */
+    private final String name;
+
+    /** True if the event is allocation-related */
+    private final boolean isAllocation;
+
+    EventType(String name, boolean isAllocation) {
+        this.name = name;
+        this.isAllocation = isAllocation;
+    }
+
+    EventType(String name) {
+        this(name, false);
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    /**
+     * @return true if the event is allocated related
+     */
+    public boolean isAllocation() {
+        return isAllocation;
+    }
+
+    public static EventType from(String name) {
+        switch (name) {
+        case "allocation-tlab":
+            return EVENT_ALLOCATION_IN_NEW_TLAB;
+        case "allocation-outside-tlab":
+            return EVENT_ALLOCATION_OUTSIDE_TLAB;
+        case "exceptions":
+            return EVENT_JAVA_EXCEPTION;
+        case "locks":
+            return EVENT_JAVA_MONITOR_BLOCKED;
+        default:
+            return EVENT_METHOD_PROFILING_SAMPLE;
+        }
+    }
+
+    public static final class EventTypeConverter implements IStringConverter<EventType> {
+        @Override
+        public EventType convert(String value) {
+            return EventType.from(value);
+        }
+    }
+}

--- a/src/main/java/com/github/chrishantha/jfr/flamegraph/output/FlameGraphOutputWriter.java
+++ b/src/main/java/com/github/chrishantha/jfr/flamegraph/output/FlameGraphOutputWriter.java
@@ -26,7 +26,7 @@ public interface FlameGraphOutputWriter {
 
     void initialize(OutputWriterParameters parameters);
 
-    void processEvent(long startTimestamp, long endTimestamp, long duration, Stack<String> stack);
+    void processEvent(long startTimestamp, long endTimestamp, long duration, Stack<String> stack, Long value);
 
     void writeOutput(BufferedWriter bufferedWriter) throws IOException;
 }

--- a/src/main/java/com/github/chrishantha/jfr/flamegraph/output/FoldedOutputWriter.java
+++ b/src/main/java/com/github/chrishantha/jfr/flamegraph/output/FoldedOutputWriter.java
@@ -29,14 +29,14 @@ public class FoldedOutputWriter implements FlameGraphOutputWriter {
     /**
      * The data model for folded stacks
      */
-    private final Map<String, Integer> stackTraceMap = new LinkedHashMap<>();
+    private final Map<String, Long> stackTraceMap = new LinkedHashMap<>();
 
     @Override
     public void initialize(OutputWriterParameters parameters) {
     }
 
     @Override
-    public void processEvent(long startTimestamp, long endTimestamp, long duration, Stack<String> stack) {
+    public void processEvent(long startTimestamp, long endTimestamp, long duration, Stack<String> stack, Long value) {
         // StringBuilder to keep stack trace
         StringBuilder stackTraceBuilder = new StringBuilder();
         boolean appendSemicolon = false;
@@ -49,18 +49,18 @@ public class FoldedOutputWriter implements FlameGraphOutputWriter {
             stackTraceBuilder.append(stack.pop());
         }
         String stackTrace = stackTraceBuilder.toString();
-        Integer count = stackTraceMap.get(stackTrace);
+        Long count = stackTraceMap.get(stackTrace);
         if (count == null) {
-            count = 1;
+            count = value;
         } else {
-            count++;
+            count += value;
         }
         stackTraceMap.put(stackTrace, count);
     }
 
     @Override
     public void writeOutput(BufferedWriter bufferedWriter) throws IOException {
-        for (Map.Entry<String, Integer> entry : stackTraceMap.entrySet()) {
+        for (Map.Entry<String, Long> entry : stackTraceMap.entrySet()) {
             bufferedWriter.write(String.format("%s %d%n", entry.getKey(), entry.getValue()));
         }
     }

--- a/src/main/java/com/github/chrishantha/jfr/flamegraph/output/JsonOutputWriter.java
+++ b/src/main/java/com/github/chrishantha/jfr/flamegraph/output/JsonOutputWriter.java
@@ -94,7 +94,7 @@ public class JsonOutputWriter implements FlameGraphOutputWriter {
     }
 
     @Override
-    public void processEvent(long startTimestamp, long endTimestamp, long duration, Stack<String> stack) {
+    public void processEvent(long startTimestamp, long endTimestamp, long duration, Stack<String> stack, Long size) {
         StackFrame frame;
         if (exportTimestamp) {
             long startTimestampSecEpoch = TimeUnit.NANOSECONDS.toSeconds(startTimestamp);

--- a/src/test/java/com/github/chrishantha/jfr/flamegraph/output/ApplicationTest.java
+++ b/src/test/java/com/github/chrishantha/jfr/flamegraph/output/ApplicationTest.java
@@ -74,7 +74,7 @@ public class ApplicationTest extends TestCase {
     }
 
     public void testEventTypeOption() throws Exception {
-        String[] args = { "-f", "temp", "-ev", "allocation-tlab" };
+        String[] args = { "-f", "temp", "-e", "allocation-tlab" };
         parseCommands(args);
         assertEquals(EventType.EVENT_ALLOCATION_IN_NEW_TLAB, jfrToFlameGraphWriter.eventType);
     }

--- a/src/test/java/com/github/chrishantha/jfr/flamegraph/output/ApplicationTest.java
+++ b/src/test/java/com/github/chrishantha/jfr/flamegraph/output/ApplicationTest.java
@@ -53,7 +53,7 @@ public class ApplicationTest extends TestCase {
 
     public void testJFRToFlameGraphWriterOutputFile() throws IOException {
         File tmp = File.createTempFile(getClass().getName(), "");
-        String[] args = {"-f", tmp.toString(), "-o", tmp.toString()};
+        String[] args = { "-f", tmp.toString(), "-o", tmp.toString() };
         parseCommands(args);
         assertTrue(tmp.exists());
         assertEquals(tmp, jfrToFlameGraphWriter.jfrdump);
@@ -62,15 +62,27 @@ public class ApplicationTest extends TestCase {
     }
 
     public void testIgnoreLineNumbersOption() throws IOException {
-        String[] args = {"-f", "temp", "-i"};
+        String[] args = { "-f", "temp", "-i" };
         parseCommands(args);
         assertTrue(jfrToFlameGraphWriter.ignoreLineNumbers);
     }
 
     public void testLiveOption() throws IOException {
-        String[] args = {"-f", "temp", "-l"};
+        String[] args = { "-f", "temp", "-l" };
         parseCommands(args);
         assertTrue(parameters.live);
+    }
+
+    public void testEventTypeOption() throws Exception {
+        String[] args = { "-f", "temp", "-ev", "allocation-tlab" };
+        parseCommands(args);
+        assertEquals(EventType.EVENT_ALLOCATION_IN_NEW_TLAB, jfrToFlameGraphWriter.eventType);
+    }
+
+    public void testEventTypeOptionDefaultValue() throws Exception {
+        String[] args = { "-f", "temp" };
+        parseCommands(args);
+        assertEquals(EventType.EVENT_METHOD_PROFILING_SAMPLE, jfrToFlameGraphWriter.eventType);
     }
 
 }


### PR DESCRIPTION
With this PR one is now also able to generate flamegraphs for the following event types:

- Allocations in a new TLAB (allocation-tlab)
- Allocation outside TLAB (allocation-outside-tlab)
- Exceptions (exceptions)
- Java Monitor Blocked (monitor-blocked)

In allocation-related flamegraphs the width of the flames represent the total amount of memory allocated in bytes;

For exceptions, the width represents the number of times exceptions were created;

For monitor blocked, the width represents the number of times a Java thread was blocked due that monitor being in use.

The create_flamegraph.sh script has been modified to add the -e option, which allows to specify the event type. For example,

`./create_flamegraph.sh -e allocation-tlab -d -f my_recording.jfr > allocation_flames.svg`

Would create a flamegraph for allocations in a new TLAB.

When the use doesn't specify an event type, method profiling sample is used by default. So, for example:

`./create_flamegraph.sh -f my_recording.jfr > flames.svg`

Would generate a flamegraph based on method profiling sample, as today.