### PR TITLE
Remove backquote from gradle instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See my blog post on "[Flame Graphs with Java Flight Recordings]" for more detail
 Build and install `jfr-flame-graph` app using
 
 ```
-./gradlew installDist`
+./gradlew installDist
 ```
 
 This will install the executable into `./build/install/jfr-flame-graph/bin`.


### PR DESCRIPTION
Looks like there is one backquote too much, here is a fix for this :)