### PR TITLE
Add support to create flame graph with JFR call stack sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ $ ./jfr-flame-graph -h
       -rv, --show-return-value
         Show return value for methods in the stack
         Default: false
+      -rev, --reverse-call-stack
+        Reverse call stacks so that it can show JFR style graph(bottom-up)
+        Default: false
       -st, --start-timestamp
         Start timestamp in seconds for filtering
         Default: -9223372036854775808

--- a/src/main/java/com/github/chrishantha/jfr/flamegraph/output/JFRToFlameGraphWriter.java
+++ b/src/main/java/com/github/chrishantha/jfr/flamegraph/output/JFRToFlameGraphWriter.java
@@ -93,6 +93,10 @@ public final class JFRToFlameGraphWriter {
             "--event"}, description = "Type of event used to generate the flamegraph", converter = EventType.EventTypeConverter.class)
     EventType eventType = EventType.METHOD_PROFILING_SAMPLE;
 
+    @Parameter(names = {"-rev",
+            "--reverse-call-stack"}, description = "Reverse call stacks so that it can show JFR style graph(bottom-up)")
+    boolean reverseCallStack;
+
     private static final String EVENT_VALUE_STACK = "(stackTrace)";
 
     private static final String PRINT_FORMAT = "%-16s: %s%n";
@@ -235,6 +239,13 @@ public final class JFRToFlameGraphWriter {
             if (frameName != null) {
                 stack.push(frameName);
             }
+        }
+        if(reverseCallStack){
+            Stack<String> stack_rev = new Stack<>();
+            while(stack != null && !stack.isEmpty()){
+                stack_rev.push(stack.pop());
+            }
+            stack = stack_rev;
         }
         return stack;
     }

--- a/src/test/java/com/github/chrishantha/jfr/flamegraph/output/ApplicationTest.java
+++ b/src/test/java/com/github/chrishantha/jfr/flamegraph/output/ApplicationTest.java
@@ -85,4 +85,9 @@ public class ApplicationTest extends TestCase {
         assertEquals(EventType.METHOD_PROFILING_SAMPLE, jfrToFlameGraphWriter.eventType);
     }
 
+    public void testReverseCallStackValue() throws Exception {
+        String[] args = {"-f", "temp", "-rev"};
+        parseCommands(args);
+        assertTrue(jfrToFlameGraphWriter.reverseCallStack);
+    }
 }


### PR DESCRIPTION
The JFR call stack is in a bottom-up style while this flame graph is top-down. When we observe flame graph it's not straightforward for us to compare the 2 charts. Adding "-rev" is to make the call stack same as JFR does.